### PR TITLE
Fix handling for non-existent or empty config files

### DIFF
--- a/funi.js
+++ b/funi.js
@@ -37,31 +37,23 @@ let cfg = {
     cli: getYamlCfg(cliCfgFile),
 };
 
-// make sure cfg params aren't empty
-// If they are, update them with some defaults
+// make sure cfg params aren't null
 if (cfg.bin === null){
-	cfg.bin = {};
-	console.log('[WARN] bin-path.yml is empty or does not exist!\n');
+    cfg.bin = {};
+    console.log('[WARN] bin-path.yml is empty or does not exist!\n');
 }
-if (!cfg.bin.hasOwnProperty('ffmpeg')) cfg.bin.ffmpeg = './bin/ffmpeg';
-if (!cfg.bin.hasOwnProperty('mkvmerge')) cfg.bin.mkvmerge = './bin/mkvmerge';
 
 if (cfg.dir === null){
-	cfg.dir = {};
-	console.log('[WARN] dir-path.yml is empty or does not exist!\n');
+    cfg.dir = {};
+    console.log('[WARN] dir-path.yml is empty or does not exist!\n');
 }
-if (!cfg.dir.hasOwnProperty('content')) cfg.dir.content = './videos/';
+
+if (!Object.prototype.hasOwnProperty.call(cfg.dir, 'content')) cfg.dir.content = './videos/';
 
 if (cfg.cli === null){
-	cfg.cli = {};
-	console.log('[WARN] cli-defaults.yml is empty or does not exist!\n');
+    cfg.cli = {};
+    console.log('[WARN] cli-defaults.yml is empty or does not exist!\n');
 }
-if (!cfg.cli.hasOwnProperty('releaseGroup')) cfg.cli.releaseGroup = "Funimation";
-if (!cfg.cli.hasOwnProperty('videoLayer')) cfg.cli.videoLayer = 7;
-if (!cfg.cli.hasOwnProperty('nServer')) cfg.cli.nServer = 1;
-if (!cfg.cli.hasOwnProperty('mp4mux')) cfg.cli.mp4mux = false;
-if (!cfg.cli.hasOwnProperty('muxSubs')) cfg.cli.muxSubs = false;
-if (!cfg.cli.hasOwnProperty('noCleanUp')) cfg.cli.noCleanUp = false;
 
 /* Normalise paths for use outside the current directory */
 for (let key of Object.keys(cfg.dir)) {

--- a/funi.js
+++ b/funi.js
@@ -40,21 +40,42 @@ let cfg = {
     cli: getYamlCfg(cliCfgFile),
 };
 
+// make sure cfg params aren't empty
+if (cfg.bin === null){
+	cfg.bin = {};
+	console.log('[WARN] bin-path.yml is empty or does not exist!\n');
+}
+if (!cfg.bin.hasOwnProperty('ffmpeg')) cfg.bin.ffmpeg = './bin/ffmpeg';
+if (!cfg.bin.hasOwnProperty('mkvmerge')) cfg.bin.mkvmerge = './bin/mkvmerge';
+
+if (cfg.dir === null){
+	cfg.dir = {};
+	console.log('[WARN] dir-path.yml is empty or does not exist!\n');
+}
+if (!cfg.dir.hasOwnProperty('content')) cfg.dir.content = './videos/';
+if (!cfg.dir.hasOwnProperty('trash')) cfg.dir.trash = "./videos/_trash/";
+
+if (cfg.cli === null){
+	cfg.cli = {};
+	console.log('[WARN] cli-defaults.yml is empty or does not exist!\n');
+}
+if (!cfg.cli.hasOwnProperty('releaseGroup')) cfg.cli.releaseGroup = "Funimation";
+if (!cfg.cli.hasOwnProperty('videoLayer')) cfg.cli.videoLayer = 7;
+if (!cfg.cli.hasOwnProperty('fileSuffix')) cfg.cli.fileSuffix = "SIZEp";
+if (!cfg.cli.hasOwnProperty('nServer')) cfg.cli.nServer = 1;
+if (!cfg.cli.hasOwnProperty('mp4mux')) cfg.cli.mp4mux = false;
+if (!cfg.cli.hasOwnProperty('muxSubs')) cfg.cli.muxSubs = false;
+if (!cfg.cli.hasOwnProperty('noCleanUp')) cfg.cli.noCleanUp = false;
+
 // token
 let token = getYamlCfg(tokenFile);
-let emptyToken = false;
-try{
-	token = token.token ? token.token : false;
-}
-catch(error){
-	token = false;
-	emptyToken = true;
-}
+if (token === null) token = false;
+else if (token.token === null) token = false;
+else token = token.token;
 
 // info if token not set
 if(!token){
-	if(emptyToken) console.log('[WARN] token.yml is empty!\n');
-    else console.log('[INFO] Token not set!\n');
+    console.log('[INFO] Token not set!\n');
 }
 
 // cli

--- a/funi.js
+++ b/funi.js
@@ -42,11 +42,19 @@ let cfg = {
 
 // token
 let token = getYamlCfg(tokenFile);
-token = token.token ? token.token : false;
+let emptyToken = false;
+try{
+	token = token.token ? token.token : false;
+}
+catch(error){
+	token = false;
+	emptyToken = true;
+}
 
 // info if token not set
 if(!token){
-    console.log('[INFO] Token not set!\n');
+	if(emptyToken) console.log('[WARN] token.yml is empty!\n');
+    else console.log('[INFO] Token not set!\n');
 }
 
 // cli


### PR DESCRIPTION
Foreword: I'm not very experienced with pull requests so I don't know if I did it right. If not, please let me know and I'll fix it so it can be merged!\
Also, I'm directly copying this from my pull request from the master since it's unmaintained.

I recently noticed that if I manually remove the contents of `token.yml` but keep the file, the program throws an error. A little playing around and I found that the same things happen with entries in other config files.

These changes fix the handling for that. Instead of throwing errors, it will warn the user that their entries are invalid and manually set them to the default.

I considering a few other things in place of hard coding in the default config values (in case they ever change), but in the end, I decided not to. My main alternative would have been to have default `cli-defaults.yml`, `bin-path.yml` and `dir-path.yml` files somewhere else that it would pull from instead. If the maintainers think that's a better idea, let me know and I can do that.